### PR TITLE
[test] Duplicate indices

### DIFF
--- a/src/test/java/com/univocity/parsers/examples/RoutineExamples.java
+++ b/src/test/java/com/univocity/parsers/examples/RoutineExamples.java
@@ -15,6 +15,7 @@
  ******************************************************************************/
 package com.univocity.parsers.examples;
 
+import com.univocity.parsers.common.DataProcessingException;
 import com.univocity.parsers.csv.*;
 import com.univocity.parsers.tsv.*;
 import org.testng.annotations.*;
@@ -217,6 +218,34 @@ public class RoutineExamples extends Example {
 		} finally {
 			statement.getConnection().close();
 		}
+		printAndValidate();
+	}
+
+	@Test(expectedExceptions = DataProcessingException.class)
+	public void example007IterateOverBeansWithDuplicates() {
+
+		//##CODE_START
+
+		// Let's configure our input format using the parser settings, as usual
+		// This configuration will be used as the base configuration for our routine.
+		CsvParserSettings parserSettings = new CsvParserSettings();
+		parserSettings.getFormat().setLineSeparator("\n");
+
+		// Here we create an instance of our routines object.
+		CsvRoutines routines = new CsvRoutines(parserSettings); // Can also use TSV and Fixed-width routines
+
+		// the iterate() method receives our annotated class and an input to parse, and return
+		// an Iterator for objects of this class.
+
+		// internally, it will create a special instance of BeanRowProcessor
+		// to handle the conversion of each record to a TestBean
+		for (TestBean_duplicates bean : routines.iterate(TestBean_duplicates.class, getReader("/examples/bean_test_duplicates.csv"))) {
+			println(bean); //let's print it out.
+		}
+
+
+		//##CODE_END
+
 		printAndValidate();
 	}
 }

--- a/src/test/java/com/univocity/parsers/examples/TestBean_duplicates.java
+++ b/src/test/java/com/univocity/parsers/examples/TestBean_duplicates.java
@@ -1,0 +1,102 @@
+/*******************************************************************************
+ * Copyright 2014 Univocity Software Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+package com.univocity.parsers.examples;
+
+import com.univocity.parsers.annotations.*;
+
+import java.math.*;
+
+public class TestBean_duplicates {
+
+    // if the value parsed in the quantity column is "?" or "-", it will be replaced by null.
+    @NullString(nulls = {"?", "-"})
+    // if a value resolves to null, it will be converted to the String "0".
+    @Parsed(defaultNullRead = "0")
+    private Integer quantity;   // The attribute type defines which conversion will be executed when processing the value.
+    // In this case, IntegerConversion will be used.
+    // The attribute name will be matched against the column header in the file automatically.
+
+    @Trim
+    @LowerCase
+    // the value for the comments attribute is in the column at index 4 (0 is the first column, so this means fifth column in the file)
+    @Parsed(index = 4)
+    private String comments;
+
+    @Trim
+    @LowerCase
+    // the value for the comments attribute is in the column at index 4 (0 is the first column, so this means fifth column in the file)
+    @Parsed(index = 4)
+    private String otherComments;
+
+    // you can also explicitly give the name of a column in the file.
+    @Parsed(field = "amount")
+    private BigDecimal amount;
+
+    @Trim
+    @LowerCase
+    // values "no", "n" and "null" will be converted to false; values "yes" and "y" will be converted to true
+    @BooleanString(falseStrings = {"no", "n", "null"}, trueStrings = {"yes", "y"})
+    @Parsed
+    private Boolean pending;
+
+    //##CLASS_END
+
+    @Override
+    public String toString() {
+        return "TestBean [quantity=" + quantity + ", comments=" + comments + ", otherComments=" + otherComments + ", amount=" + amount + ", pending=" + pending + "]";
+    }
+
+    public Integer getQuantity() {
+        return quantity;
+    }
+
+    public void setQuantity(Integer quantity) {
+        this.quantity = quantity;
+    }
+
+    public String getComments() {
+        return comments;
+    }
+
+    public void setComments(String comments) {
+        this.comments = comments;
+    }
+
+    public String getOtherComments() {
+        return otherComments;
+    }
+
+    public void setOtherComments(String comments) {
+        this.otherComments = comments;
+    }
+
+    public BigDecimal getAmount() {
+        return amount;
+    }
+
+    public void setAmount(BigDecimal amount) {
+        this.amount = amount;
+    }
+
+    public Boolean getPending() {
+        return pending;
+    }
+
+    public void setPending(Boolean pending) {
+        this.pending = pending;
+    }
+
+}

--- a/src/test/resources/examples/bean_test_duplicates.csv
+++ b/src/test/resources/examples/bean_test_duplicates.csv
@@ -1,0 +1,3 @@
+date,			amount,		quantity,	pending	,comments               ,otherComments
+10-oct-2001,	555.999,	1,			yEs		,?                      ,?
+2001-10-10,		,			?,			N		,"  "" dang ""  "       ,"lawl"


### PR DESCRIPTION
Add test to check DataProcessingException is thrown when duplicate field indices are given in the valdiate mapping function.

Increase branch coverage from 102/137 to 105/137.

resolve #3