### PR TITLE
[test] Add two test cases for AnnotationHelper::applyFormatSettings, …

### DIFF
--- a/src/test/java/com/univocity/parsers/annotations/AnnotationHelperTest.java
+++ b/src/test/java/com/univocity/parsers/annotations/AnnotationHelperTest.java
@@ -19,9 +19,12 @@ import com.univocity.parsers.annotations.helpers.AnnotationHelper;
 
 import java.io.*;
 import java.lang.reflect.Constructor;
+import java.text.SimpleDateFormat;
 import java.util.*;
 
 import com.univocity.parsers.annotations.meta.*;
+import com.univocity.parsers.common.DataProcessingException;
+import com.univocity.parsers.common.DataProcessingExceptionTest;
 import com.univocity.parsers.common.processor.*;
 import com.univocity.parsers.csv.*;
 import org.testng.annotations.*;
@@ -62,4 +65,17 @@ public class AnnotationHelperTest {
 				"thisisctest;;\n");
 	}
 
+	@Test(expectedExceptions = DataProcessingException.class, expectedExceptionsMessageRegExp = "Illegal format setting .*")
+  public void testApplyFormatSettingsOnIllegalFormatSetting() {
+    SimpleDateFormat sdf = new SimpleDateFormat();
+    String [] str = {"abc"};
+    AnnotationHelper.applyFormatSettings(sdf, str);
+	}
+
+  @Test(expectedExceptions = DataProcessingException.class, expectedExceptionsMessageRegExp = "Cannot find properties .*")
+	public void testApplyFormatSettingsOnMissingProperties() {
+    SimpleDateFormat sdf = new SimpleDateFormat();
+    String [] str = {"abc=aba"};
+    AnnotationHelper.applyFormatSettings(sdf, str);
+  }
 }


### PR DESCRIPTION
Add two tests for the method AnnotationHelper::applyFormatSettings. 
The tests cover two cases where DataProcessingException exceptions are thrown with different messages regarding the case. 
In the first case there is an illegal format setting.
In the second case there are some missing properties.